### PR TITLE
Update cloudtube.config.js

### DIFF
--- a/examples/cloudtube.config.js
+++ b/examples/cloudtube.config.js
@@ -1,15 +1,17 @@
 module.exports = {
-        /*
-          Copy this file to `config.js`, and add options here.
-          They'll override the options from `utils/constants.js`.
-          For example, the next block changes the default instance.
-        */
-
+/*
+  Copy this file to `config.js`, and add options here.
+  They'll override the options from `utils/constants.js`.
+  For example, the next block changes the default instance.
+*/
         user_settings: {
                 instance: {
                         default: "http://newleaf:3000"
                 }
         },
+        /*
+          If cloudtube and Newleaf is not in same docker-network, you need to also set local_instance_origin.
+        */
         server_setup: {
                 local_instance_origin: "http://newleaf:3000"
         }

--- a/examples/cloudtube.config.js
+++ b/examples/cloudtube.config.js
@@ -1,13 +1,16 @@
 module.exports = {
-	/*
-	  Copy this file to `config.js`, and add options here.
-	  They'll override the options from `utils/constants.js`.
-	  For example, the next block changes the default instance.
-	*/
+        /*
+          Copy this file to `config.js`, and add options here.
+          They'll override the options from `utils/constants.js`.
+          For example, the next block changes the default instance.
+        */
 
-	user_settings: {
-		instance: {
-			default: "http://newleaf:3000"
-		}
-	}
+        user_settings: {
+                instance: {
+                        default: "http://newleaf:3000"
+                }
+        },
+        server_setup: {
+                local_instance_origin: "http://newleaf:3000"
+        }
 }


### PR DESCRIPTION
If docker is not in same network you need to also set `local_instance_origin` to avoid this error : 
```
FetchError: request to http://localhost:3000/api/v1/channels/UChV2oq_a-UZfJF-UiW0u-DQ/latest failed, reason: connect ECONNREFUSED 127.0.0.1:3000
```